### PR TITLE
feat!: add support to oboukili/argocd >= v5

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -109,7 +109,7 @@ This module must be one of the first ones to be deployed and consequently it nee
 
 The following requirements are needed by this module:
 
-- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 - [[requirement_null]] <<requirement_null,null>> (>= 3)
 
@@ -119,13 +119,13 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_aws]] <<provider_aws,aws>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Modules
 
@@ -188,7 +188,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.1"`
+Default: `"v1.0.2"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -274,7 +274,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
 |[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
@@ -284,10 +284,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_aws]] <<provider_aws,aws>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Modules
@@ -331,7 +331,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.1"`
+|`"v1.0.2"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/main.tf
+++ b/main.tf
@@ -123,14 +123,19 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = var.app_autosync
+      automated {
+        prune       = var.app_autosync.prune
+        self_heal   = var.app_autosync.self_heal
+        allow_empty = var.app_autosync.allow_empty
+      }
 
       retry {
-        backoff = {
-          duration     = ""
-          max_duration = ""
+        backoff {
+          duration     = "20s"
+          max_duration = "2m"
+          factor       = "2"
         }
-        limit = "0"
+        limit = "5"
       }
 
       sync_options = [

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source  = "oboukili/argocd"
-      version = ">= 4"
+      version = ">= 5"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

This PR adds support to the Argo CD Terraform provider version >= 5, which is needed to support versions of Argo CD >= 2.7.x.

## Breaking change

- [x] Yes (in the module itself): see https://github.com/oboukili/terraform-provider-argocd/releases/tag/v5.0.0

## Tests executed on which distribution(s)

- [x] EKS
