### PR TITLE
feat: add variables to set AppProject, labels and destination cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,11 +121,11 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_aws]] <<provider_aws,aws>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Modules
 
@@ -182,13 +182,37 @@ Type: `string`
 
 Default: `"cluster"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -328,10 +352,28 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,10 @@ resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "efs-csi-driver-${var.destination_cluster}" : "efs-csi-driver"
     namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "efs-csi-driver"
+      "cluster"     = var.destination_cluster
+    }, var.argocd_labels)
   }
 
   timeouts {

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "argocd_project" {
   default     = null
 }
 
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "destination_cluster" {
   description = "Destination cluster where the application should be deployed."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,18 @@ variable "argocd_namespace" {
   type        = string
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
+variable "destination_cluster" {
+  description = "Destination cluster where the application should be deployed."
+  type        = string
+  default     = "in-cluster"
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR:
- Adds the required variables and configuration to allow the module to be deployed on a different cluster than Argo CD.
- Adds the possibility of placing the application inside a specified Argo CD project in order to avoid having a single project for each application throughout multiple clusters.
- Adds labels and a variable to add more labels to the Argo CD application to make it easier to sort applications on the web interface of Argo CD.

**All these changes are made in preparation for having a centralized Argo CD that controls applications throughout multiple clusters.**

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
