### PR TITLE
feat: add variable to set resources with default values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -206,7 +206,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.4.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -245,6 +245,44 @@ Default:
 Description: IDs of the other modules on which this module depends on.
 
 Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for aws-efs-csi-driver's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values."
+
+NOTE: These are the same values as the defaults on the Helm chart aws-efs-csi-driver.
+
+Type:
+[source,hcl]
+----
+object({
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    node = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+  })
+----
 
 Default: `{}`
 
@@ -353,7 +391,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.4.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>
@@ -391,6 +429,45 @@ object({
 |[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 |IDs of the other modules on which this module depends on.
 |`map(string)`
+|`{}`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for aws-efs-csi-driver's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values."
+
+NOTE: These are the same values as the defaults on the Helm chart aws-efs-csi-driver.
+
+|
+
+[source]
+----
+object({
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    node = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
 |`{}`
 |no
 

--- a/locals.tf
+++ b/locals.tf
@@ -15,6 +15,16 @@ locals {
             "eks.amazonaws.com/role-arn" = var.iam_role_arn != null ? var.iam_role_arn : module.iam_assumable_role_efs.iam_role_arn
           }
         }
+        resources = {
+          requests = { for k, v in var.resources.controller.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.controller.limits : k => v if v != null }
+        }
+      }
+      node = {
+        resources = {
+          requests = { for k, v in var.resources.node.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.node.limits : k => v if v != null }
+        }
       }
     }
   }]

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,40 @@ variable "dependency_ids" {
 ## Module variables
 #######################
 
+variable "resources" {
+  description = <<-EOT
+    Resource limits and requests for aws-efs-csi-driver's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values."
+
+    NOTE: These are the same values as the defaults on the Helm chart aws-efs-csi-driver.
+  EOT
+  type = object({
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    node = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+  })
+  default = {}
+}
+
 variable "efs_file_system_id" {
   description = "EFS Filesystem ID to use by the CSI driver to create volumes."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR adds a variable to set resources' limits and requests on the module components.

Having default values is good practice to prevent that our components could eventually starve other workloads on the cluster. However, these should probably be adapted in production clusters and are only a safeguard in case someone forgets to set them.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)