### PR TITLE
fix: change IAM role policy to allow dynamic volume provisioning

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,11 +121,11 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_aws]] <<provider_aws,aws>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Modules
 
@@ -143,9 +143,9 @@ The following resources are used by this module:
 
 - https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] (resource)
 - https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] (resource)
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.efs] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy[aws_iam_policy.AmazonEFSCSIDriverPolicy] (data source)
 - https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
 
 === Required Inputs
@@ -206,7 +206,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.2.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -332,10 +332,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_aws]] <<provider_aws,aws>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Modules
@@ -353,9 +353,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name |Type
 |https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] |resource
 |https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] |resource
-|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.efs] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy[aws_iam_policy.AmazonEFSCSIDriverPolicy] |data source
 |https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] |data source
 |===
 
@@ -391,7 +391,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.2.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>


### PR DESCRIPTION
## Description of the changes

I tried to do dynamic provisioning with this module but it does not work because of permissions. There is a AWS managed policy for the efs driver so I propose we use it.

The current actions are embedded in the AmazonEFSCSIDriverPolicy.

## Breaking change

- [X] No

## Tests executed on which distribution(s)

- [X] EKS (AWS)
